### PR TITLE
compare to an empty *byte*string

### DIFF
--- a/workshop/SeqBuddy.py
+++ b/workshop/SeqBuddy.py
@@ -661,7 +661,7 @@ def _guess_format(_input):
     if str(type(_input)) == "<class '_io.TextIOWrapper'>" or isinstance(_input, StringIO):
         if not _input.seekable():  # Deal with input streams (e.g., stdout pipes)
             _input = StringIO(_input.read())
-        if _input.read() == "":
+        if _input.read() == b"":
             return "empty file"
         _input.seek(0)
 


### PR DESCRIPTION
This avoids casting `_input.read()` from ascii to unicode, which can result in UnicodeDecodeError