### PR TITLE
open input files with an explicit encoding

### DIFF
--- a/workshop/AlignBuddy.py
+++ b/workshop/AlignBuddy.py
@@ -147,7 +147,7 @@ class AlignBuddy(object):
                 alignments = list(AlignIO.parse(_input, self.in_format))
 
         elif os.path.isfile(_input):
-            with open(_input, "r") as _input:
+            with open(_input, "r", encoding='utf-8') as _input:
                 if self.in_format == "phylipss":
                     alignments = list(br.phylip_sequential_read(_input.read(), relaxed=False))
                 elif self.in_format == "phylipsr":
@@ -307,7 +307,7 @@ def guess_format(_input):  # _input can be list, SeqBuddy object, file handle, o
 
     # If input is a handle or path, try to read the file in each format, and assume success if not error and # seqs > 0
     if os.path.isfile(str(_input)):
-        _input = open(_input, "r")
+        _input = open(_input, "r", encoding='utf-8')
 
     if str(type(_input)) == "<class '_io.TextIOWrapper'>" or isinstance(_input, StringIO):
         if not _input.seekable():  # Deal with input streams (e.g., stdout pipes)

--- a/workshop/PhyloBuddy.py
+++ b/workshop/PhyloBuddy.py
@@ -347,7 +347,7 @@ def _guess_format(_input):
 
     # If input is a handle or path, try to read the file in each format, and assume success if not error and # trees > 0
     if os.path.isfile(str(_input)):
-        _input = open(_input, "r")
+        _input = open(_input, "r", encoding='utf-8')
 
     if str(type(_input)) == "<class '_io.TextIOWrapper'>" or isinstance(_input, StringIO):
         # Die if file is empty


### PR DESCRIPTION
this fixes some UnicodeDecodeErrors when the default system encoding is not utf-8.  I didn't change all `open` calls because some of them may not be unicode.